### PR TITLE
feat: Add Docker configuration for OpenStreetMap with data cleaning

### DIFF
--- a/docs/openstreetmap/README.md
+++ b/docs/openstreetmap/README.md
@@ -1,0 +1,20 @@
+# Configuration OpenStreetMap
+
+Ce projet met en place un serveur de dalles OpenStreetMap à l'aide de Docker.
+
+## Démarrage rapide
+
+1.  **Téléchargez un extrait de carte OpenStreetMap** au format `.pbf`. Par exemple, depuis [Geofabrik](http://download.geofabrik.de/).
+2.  **Placez le fichier `.pbf`** dans le répertoire `servers/openstreetmap/data`.
+3.  **Renommez-le** en `data.osm.pbf`.
+4.  **Exécutez Docker Compose :**
+
+    ```bash
+    docker-compose up -d
+    ```
+
+5.  **Accédez au service** sur `http://localhost:8080`.
+
+## Personnalisation
+
+Le style de la carte et d'autres paramètres peuvent être configurés en modifiant les fichiers dans `servers/openstreetmap`.

--- a/servers/openstreetmap/Dockerfile
+++ b/servers/openstreetmap/Dockerfile
@@ -6,6 +6,10 @@ ENV THREADS=4
 # Niveau de zoom maxi généré à la volée (tu peux limiter à 14–16 si besoin)
 ENV MAX_ZOOM=19
 
-# Rien d’autre n’est requis : l’image contient osm2pgsql, renderd, Apache, style OSM Carto.
-# Le style par défaut sera utilisé (modifiable, voir notes plus bas).
+# Copie et exécution du script de nettoyage
+COPY cleanup.sh /usr/local/bin/cleanup.sh
+RUN chmod +x /usr/local/bin/cleanup.sh
+
+# Ajout du script de nettoyage à l'exécution
+RUN echo "/usr/local/bin/cleanup.sh" >> /usr/local/bin/run.sh
 

--- a/servers/openstreetmap/cleanup.sh
+++ b/servers/openstreetmap/cleanup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Se connecter à la base de données PostGIS et supprimer les données indésirables
+psql -d gis -c "
+-- Suppression des routes et chemins
+DELETE FROM planet_osm_line WHERE highway IS NOT NULL;
+DELETE FROM planet_osm_polygon WHERE highway IS NOT NULL;
+DELETE FROM planet_osm_roads WHERE highway IS NOT NULL;
+
+-- Suppression des bâtiments
+DELETE FROM planet_osm_polygon WHERE building IS NOT NULL;
+
+-- Suppression des zones résidentielles et autres constructions
+DELETE FROM planet_osm_polygon WHERE landuse IN ('residential', 'commercial', 'industrial', 'retail');
+
+-- Suppression des barrières
+DELETE FROM planet_osm_line WHERE barrier IS NOT NULL;
+
+-- Suppression des lignes électriques
+DELETE FROM planet_osm_line WHERE power IN ('line', 'minor_line');
+"
+
+echo "Nettoyage de la carte terminé."


### PR DESCRIPTION
This commit introduces a Docker-based setup for an OpenStreetMap tile server.

It includes:
- A Dockerfile based on `overv/openstreetmap-tile-server`.
- A `docker-compose.yml` file for easy startup.
- A `cleanup.sh` script that removes man-made structures (roads, buildings, etc.) from the map data after import.
- A `README.md` file in `docs/openstreetmap` with instructions on how to use the setup.