### PR TITLE
Fix tileserver-gl startup error by adding command

### DIFF
--- a/docker_compose_dev.yml
+++ b/docker_compose_dev.yml
@@ -9,6 +9,7 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
+    command: run
     volumes:
       # Tu stockes les données .mbtiles et éventuellement config.json ici
       - ./servers/openstreetmap/data:/data:rw


### PR DESCRIPTION
The tileserver-gl container was exiting upon startup because it was missing a command. The entrypoint of the `overv/openstreetmap-tile-server` image expects either `import` or `run` as an argument.

This change adds `command: run` to the `tileserver` service in the `docker_compose_dev.yml` file to ensure the container starts correctly.