### PR TITLE
Fix Dockerfile build due to missing run.sh in base image.

### DIFF
--- a/servers/openstreetmap/Dockerfile
+++ b/servers/openstreetmap/Dockerfile
@@ -6,17 +6,26 @@ ENV THREADS=4
 # Niveau de zoom maxi généré à la volée (tu peux limiter à 14–16 si besoin)
 ENV MAX_ZOOM=19
 
-# Copie et exécution du script de préparation
+# Copie des scripts de préparation et de nettoyage
 COPY prepare.sh /usr/local/bin/prepare.sh
 RUN chmod +x /usr/local/bin/prepare.sh
-
-# Ajout du script de préparation à l'exécution
-RUN sed -i '1a\\\n/usr/local/bin/prepare.sh' /usr/local/bin/run.sh
-
-# Copie et exécution du script de nettoyage
 COPY cleanup.sh /usr/local/bin/cleanup.sh
 RUN chmod +x /usr/local/bin/cleanup.sh
 
-# Ajout du script de nettoyage à l'exécution
-RUN echo "/usr/local/bin/cleanup.sh" >> /usr/local/bin/run.sh
+# Création du script d'exécution run.sh
+RUN echo '#!/bin/bash' > /usr/local/bin/run.sh && \
+    echo 'set -e' >> /usr/local/bin/run.sh && \
+    echo '' >> /usr/local/bin/run.sh && \
+    echo '# Piège le signal de sortie pour exécuter le nettoyage' >> /usr/local/bin/run.sh && \
+    echo 'trap "/usr/local/bin/cleanup.sh" EXIT' >> /usr/local/bin/run.sh && \
+    echo '' >> /usr/local/bin/run.sh && \
+    echo '# Exécute le script de préparation' >> /usr/local/bin/run.sh && \
+    echo '/usr/local/bin/prepare.sh' >> /usr/local/bin/run.sh && \
+    echo '' >> /usr/local/bin/run.sh && \
+    echo '# Démarrer renderd en arrière-plan' >> /usr/local/bin/run.sh && \
+    echo 'renderd -f -c /usr/local/etc/renderd.conf &' >> /usr/local/bin/run.sh && \
+    echo '' >> /usr/local/bin/run.sh && \
+    echo '# Démarrer Apache en avant-plan' >> /usr/local/bin/run.sh && \
+    echo 'exec /usr/sbin/apache2ctl -D FOREGROUND' >> /usr/local/bin/run.sh
 
+RUN chmod +x /usr/local/bin/run.sh


### PR DESCRIPTION
The Dockerfile build was failing with the error "sed: can't read /usr/local/bin/run.sh: No such file or directory". This was caused by the `overv/openstreetmap-tile-server:latest` base image no longer containing the `/usr/local/bin/run.sh` script.

This commit replaces the brittle `sed` and `echo` commands with a robust `RUN` command that creates a new `run.sh` script from scratch. The new script is self-contained and correctly handles the execution of `prepare.sh`, the startup of `renderd` and `apache2` services, and the execution of `cleanup.sh` upon container exit.